### PR TITLE
Typo fixed in Listeners<ListenerClass> docs

### DIFF
--- a/modules/vf_concurrent/threads/vf_Listeners.h
+++ b/modules/vf_concurrent/threads/vf_Listeners.h
@@ -190,7 +190,7 @@
       }
 
       // Notify listeners.
-      listeners.call (&Listener::onOutputLevelChanged, newOutputLevel);
+      m_listeners.call (&Listener::onOutputLevelChanged, newOutputLevel);
     }
 
   private:
@@ -200,6 +200,8 @@
 
       float outputLevel;
     };
+
+	Listeners<Listener> m_listeners;
 
     ConcurrentState <State> m_state;
 


### PR DESCRIPTION
Added omitted Listeners<ListenerClass> member from AudioDeviceOutput example class.
